### PR TITLE
fix bug that name and title not showing correctly

### DIFF
--- a/app/views/shared/_sidebar_employee.html.erb
+++ b/app/views/shared/_sidebar_employee.html.erb
@@ -2,8 +2,8 @@
   <div class="d-flex align-items-center mt-3 ms-3 mb-4">
     <%= image_tag "https://kitt.lewagon.com/placeholder/users/cveneziani", class: "avatar-bordered" %>
     <div class="info ms-2">
-      <h5 class="username m-0"><%= @user.name %></h5>
-      <p class="jobtitle m-0"><%= @user.job_title %></p>
+      <h5 class="username m-0"><%= current_user.name %></h5>
+      <p class="jobtitle m-0"><%= current_user.job_title %></p>
     </div>
   </div>
   <div class="side-bar-items m-3">

--- a/app/views/shared/_sidebar_manager.html.erb
+++ b/app/views/shared/_sidebar_manager.html.erb
@@ -2,8 +2,8 @@
   <div class="d-flex align-items-center mt-3 ms-3 mb-4">
     <%= image_tag "https://res.cloudinary.com/wagon/image/upload/c_fill,g_face,h_200,w_200/v1673190740/pyp2lkzx5ec4awqextwq.jpg", class: "avatar-bordered shadow" %>
     <div class="info ms-2">
-      <h5 class="username m-0"><%= @user.name %></h5>
-      <p class="jobtitle m-0"><%= @user.job_title %></p>
+      <h5 class="username m-0"><%= current_user.name %></h5>
+      <p class="jobtitle m-0"><%= current_user.job_title %></p>
     </div>
   </div>
   <div class="side-bar-items m-3">


### PR DESCRIPTION
- when viewing employee individual profile page, the name and title in sidebar changed to that employee's name and title.
- solved this issue, now it is showing the current user name and title