### PR TITLE
Change slack channel

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -18,7 +18,7 @@ class TasksController < ApplicationController
     if @task.save
       # SlackClient.client.chat_postMessage(channel: '#general', blocks: BuildSlackMessageService.new(@task).call)
       message = BuildSlackMessageService.new.call(@task)
-      SendSlackMessageService.new(channel: '#general', message: message).call
+      SendSlackMessageService.new(channel: '#tasks-notifications', message: message).call
       redirect_to users_path
     else
       render "users/dashboard", status: :unprocessable_entity, locals: { timesheet_new: Timesheet.new }

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -42,7 +42,7 @@ class TasksController < ApplicationController
 
     if @task.status == 'done'
       message = BuildSlackMessageService.new.task_done_msg(@task)
-      SendSlackMessageService.new(channel: '#general', message: message).call
+      SendSlackMessageService.new(channel: '#tasks-notifications', message: message).call
     end
   end
 

--- a/app/controllers/timesheets_controller.rb
+++ b/app/controllers/timesheets_controller.rb
@@ -23,7 +23,7 @@ class TimesheetsController < ApplicationController
     authorize @timesheet
     if @timesheet.save
       message = BuildSlackMessageService.new.timelog(@timesheet)
-      SendSlackMessageService.new(channel: '#general', message: message).call
+      SendSlackMessageService.new(channel: '#clock-in-out-channel', message: message).call
       redirect_to dashboard_path
     else
       render "users/dashboard", status: :unprocessable_entity
@@ -40,7 +40,7 @@ class TimesheetsController < ApplicationController
     @timesheet.update(timesheet_params)
 
     message = BuildSlackMessageService.new.timeout(@timesheet)
-    SendSlackMessageService.new(channel: '#general', message: message).call
+    SendSlackMessageService.new(channel: '#clock-in-out-channel', message: message).call
 
     authorize @timesheet
     redirect_to dashboard_path

--- a/app/services/build_slack_message_service.rb
+++ b/app/services/build_slack_message_service.rb
@@ -28,7 +28,7 @@ class BuildSlackMessageService
         "type": "section",
         "text": {
           "type": "mrkdwn",
-          "text": ":fireworks: *Task Completed!*\n*#{task.task_title} marked as done,*\n\nContact your manager if you have any questions.\n\n<https://www.promgr.tech/dashboard|View task details>"
+          "text": ":fireworks: *Task Completed!*\n*#{task.task_title} marked as done,*\n\nContact your manager if you have any questions.\n\n<https://www.promgr.tech/tasks|View tasks calendar>"
         }
       }
     ]

--- a/app/services/build_slack_message_service.rb
+++ b/app/services/build_slack_message_service.rb
@@ -8,7 +8,7 @@ class BuildSlackMessageService
         "type": "section",
         "text": {
           "type": "mrkdwn",
-          "text": ":exclamation: *New task added*\n*Title: #{task.task_title}*\nDue date: #{task.due_date.strftime("%a %b %e at %l:%M %p")}"
+          "text": ":exclamation: *New task added*\n*Title: #{task.task_title}*\n*Due date: #{task.due_date.strftime("%a %b %e at %l:%M %p")}*"
         }
       },
       {

--- a/app/services/build_slack_message_service.rb
+++ b/app/services/build_slack_message_service.rb
@@ -41,7 +41,7 @@ class BuildSlackMessageService
         "text": {
           "type": "mrkdwn",
           "text": "Good morning everyone. Remember to clock in."
-        },
+        }
       },
       {
         "type": "actions",
@@ -69,7 +69,7 @@ class BuildSlackMessageService
         "text": {
           "type": "mrkdwn",
           "text": " #{@timesheet.user.name} logged in at #{@timesheet.time_in} "
-        },
+        }
       }
     ]
   end
@@ -82,7 +82,7 @@ class BuildSlackMessageService
         "text": {
           "type": "mrkdwn",
           "text": " #{@timesheet.user.name} logged out at #{@timesheet.time_out} "
-        },
+        }
       }
     ]
   end

--- a/app/services/build_slack_message_service.rb
+++ b/app/services/build_slack_message_service.rb
@@ -15,7 +15,7 @@ class BuildSlackMessageService
         "type": "section",
         "text": {
           "type": "mrkdwn",
-          "text": "#{task.users.pluck(:name).join(', ')} please check the task details and contact your manager if you have any questions.\n\n<https://www.promgr.tech/dashboard|View task details>"
+          "text": "#{task.users.pluck(:name).join(', ')} please check the task details and contact your manager if you have any questions.\n\n<https://www.promgr.tech/tasks|View tasks calendar>"
         }
       }
     ]


### PR DESCRIPTION
- Change the channel from #general to #tasks-notifications when task created and task done
- Change the channel from #general to #clock-in-out-channel when employees clock in and out
- Change the link in Slack message from dashboard to calendar/tasks page